### PR TITLE
Update docker-compose.yml.tmpl

### DIFF
--- a/docker/docker-compose.yml.tmpl
+++ b/docker/docker-compose.yml.tmpl
@@ -13,28 +13,30 @@ services:
       - ./entrypoint.sh:/var/www/mercator/docker/entrypoint.sh:ro
       # ne peut pas être read-only (commande php artisan key:generate le modifie)
       - ./.env:/var/www/mercator/.env
+      # map la database sqlite sur le disque de l'hôte
+      - ./data/sql/:/var/www/mercator/sql/
       # entrypoint: /bin/sleep 3600 # pour debug
       #   - ./:/var/www
     ports:
       - 8000:8000
     networks:
       - local
-
-  db:
-    image: mysql:5.7
-    restart: unless-stopped
-    environment:
-      MYSQL_DATABASE: ${DB_DATABASE}
-      MYSQL_USER: ${DB_USERNAME}
-      MYSQL_PASSWORD: ${DB_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-      # MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-    volumes:
-      - db:/var/lib/mysql
-      - ./data/backup:/backup
-      - ./bin/mysql:/app/
-    networks:
-      - local
+  # Non fonctionnel pour le moment la database utilisé par défaut est interne au conteneur APP
+  #db:
+  #  image: mysql:5.7
+  #  restart: unless-stopped
+  #  environment:
+  #    MYSQL_DATABASE: ${DB_DATABASE}
+  #    MYSQL_USER: ${DB_USERNAME}
+  #    MYSQL_PASSWORD: ${DB_PASSWORD}
+  #    MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+  #    # MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+  #  volumes:
+  #    - db:/var/lib/mysql
+  #    - ./data/backup:/backup
+  #    - ./bin/mysql:/app/
+  #  networks:
+  #    - local
 
 #   nginx:
 #     image: nginx:alpine


### PR DESCRIPTION
Ajout du map volume hôte database vers database sqlite du conteneur pour quel soit gardé en mémoire et réutilisé après chaque recompilation d'image ou arrêt.

Conteneur mysql non fonctionnel pour le moment la database utilisé par défaut est interne au conteneur APP